### PR TITLE
Ack should be length of expected output

### DIFF
--- a/evolver/conf.yml
+++ b/evolver/conf.yml
@@ -20,7 +20,7 @@ experimental_params:
     recurring: true
     fields_expected_outgoing: 17
     fields_expected_incoming: 17
-    value: ['30', '30', '30', '30', '30', '30', '30', '30', '30', '30', '30', '30', '30', '30', '30', '30']
+    value: ['4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095']
   stir:
     recurring: true
     fields_expected_outgoing: 17
@@ -56,7 +56,7 @@ serial_end_outgoing: "_!"
 serial_end_incoming: end
 serial_port: '/dev/ttyAMA0'
 serial_baudrate: 9600
-serial_timeout: 0.15
+serial_timeout: 0.3
 
 recurring_command_char: r
 immediate_command_char: i

--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -251,6 +251,8 @@ def run_commands():
     return data
 
 def serial_communication(param, value, comm_type):
+    serial_connection.reset_input_buffer()
+    serial_connection.reset_output_buffer()
     output = []
 
     # Check that parameters being sent to arduino match expected values
@@ -295,7 +297,9 @@ def serial_communication(param, value, comm_type):
         raise EvolverSerialError('Error: Incorect response character.\n\tExpected: ' + evolver_conf['data_response_char'] + '\n\tFound: ' + returned_data[0])
 
     # ACKNOWLEDGE - lets arduino know it's ok to run any commands (super important!)
-    serial_output = param + evolver_conf['acknowledge_char'] + ',' + evolver_conf['serial_end_outgoing']
+    serial_output = [''] * fields_expected_outgoing
+    serial_output[0] = evolver_conf['acknowledge_char']
+    serial_output = param + ','.join(serial_output) + ',' + evolver_conf['serial_end_outgoing']
     print(serial_output, flush = True)
     serial_connection.write(bytes(serial_output, 'UTF-8'))
 


### PR DESCRIPTION
Signed-off-by: Zachary Heins <zackheins@gmail.com>

# What? Why?
The ack for the serial communications should be of the correct length, and slows down the timeout for serial for `stir`. 
Changes proposed in this pull request:
- Use the expected output length from conf file for ack serial
- Reset the input/output buffer for every serial comm to prevent one param from effecting another
- Set timeout in conf to 0.3

# Checks
- [x] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
