### PR TITLE
Fixed newline and immediate command issues

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -56,7 +56,7 @@ async def on_command(sid, data):
 
     if immediate:
         clear_broadcast(param)
-        command_queue.insert(0, {'param': param, 'value': value, 'type': COMMAND})
+        command_queue.insert(0, {'param': param, 'value': value, 'type': IMMEDIATE}
 
 @sio.on('getconfig', namespace = '/dpu-evolver')
 async def on_getlastcommands(sid, data):


### PR DESCRIPTION
Signed-off-by: Zachary Heins <zackheins@gmail.com>

# What? Why?
Somehow we ended up with MS-DOS cr/lf in the file. I have no idea why this happend, but it seems like something weird happened with my text editor settings. I also missed a `COMMAND` final var that needed to be changed to `IMMEDIATE`
Changes proposed in this pull request:
- Fixed all the newlines to unix style using `sed`
- Changed the final variable to the correct one in the `command` event

# Checks
- [x] Updated the documentation. I'm going to go do this now on the wiki to document how commands work. A script is also going up on the DPU repo.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
