### PR TITLE
print_exc on serial comms to stdout

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -4,6 +4,7 @@ import evolver
 import time
 import asyncio
 import json
+import sys
 import os
 import yaml
 from traceback import print_exc
@@ -246,8 +247,7 @@ def run_commands():
             if returned_data is not None:
                 data[command['param']] = returned_data
         except (TypeError, ValueError, serial.serialutil.SerialException, EvolverSerialError) as e:
-            print(str(e.__class__.__name__), flush = True)
-            print_exc()
+            print_exc(file = sys.stdout)
     return data
 
 def serial_communication(param, value, comm_type):


### PR DESCRIPTION
Signed-off-by: Zachary Heins <zackheins@gmail.com>

# What? Why?
print_exc on serial communication exceptions was going to stderr, which obfuscated problems when viewing the logs.
Changes proposed in this pull request:
- `print_exc()` in `run_commands` is passed `sys.stdout`

# Checks
- [ ] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
