### PR TITLE
Adding delay after ack

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -303,6 +303,9 @@ def serial_communication(param, value, comm_type):
     print(serial_output, flush = True)
     serial_connection.write(bytes(serial_output, 'UTF-8'))
 
+    # This is necessary to allow the ack to be fully written out to samd21 and for them to fully read
+    time.sleep(.05)
+
     if returned_data[0] == evolver_conf['data_response_char']:
         returned_data = returned_data[1:]
     else:


### PR DESCRIPTION
Signed-off-by: Zachary Heins <zackheins@gmail.com>

# What? Why?

Adds a delay after the ack is written out on the serial comms line. @mgalardini and I noticed that the `stringComplete` boolean wasn't being set properly on the arduinos after the ack was written. Printing out the characters showed that the message was being truncated by the next command. This meant recurring commands were writing over each other and not being properly executed.

Changes proposed in this pull request:
- Add a 50ms delay after the ack is written to serial. Tested with pump and stir.

# Checks
- [x] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).