### PR TITLE
Avoid corner cases where arduino sends back weird chars

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -277,7 +277,7 @@ def serial_communication(param, value, comm_type):
     serial_connection.write(bytes(serial_output, 'UTF-8'))
 
     # Read and process the response
-    response = serial_connection.readline().decode('UTF-8')
+    response = serial_connection.readline().decode('UTF-8', errors='ignore')
     print(response, flush = True)
     address = response[0:len(param)]
     if address != param:


### PR DESCRIPTION
# What? Why?

Corner case observed with the temperature arduino, with char
"\xff" added at the end of the data response. This change ignores
these kinds of glitches, leading to a successful exchange of messages.

# Checks
- [x] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).