### PR TITLE
Fixes server freezing when commands with nans are handled

### DIFF
--- a/evolver/evolver.py
+++ b/evolver/evolver.py
@@ -38,14 +38,14 @@ if __name__ == '__main__':
     last_time = None
     running = False
     while True:
-        current_time = time.time()
-        commands_in_queue = evolver_server.get_num_commands() > 0
+        try:
+            current_time = time.time()
+            commands_in_queue = evolver_server.get_num_commands() > 0
 
-        if (last_time is None or current_time - last_time > conf['broadcast_timing'] or commands_in_queue) and not running:
-            last_time = current_time
-            try:
+            if (last_time is None or current_time - last_time > conf['broadcast_timing'] or commands_in_queue) and not running:
+                last_time = current_time
                 running = True
                 bloop.run_until_complete(evolver_server.broadcast(commands_in_queue))
                 running = False
-            except:
-                pass
+        except:
+            pass

--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -362,7 +362,6 @@ async def broadcast(commands_in_queue):
     broadcast_data['config'] = evolver_conf['experimental_params']
     if not commands_in_queue:
         print('Broadcasting data', flush = True)
-        print(broadcast_data)
+        print(broadcast_data, flush = True)
         broadcast_data['ip'] = evolver_conf['evolver_ip']
         await sio.emit('broadcast', broadcast_data, namespace='/dpu-evolver')
-


### PR DESCRIPTION
# What? Why?
Prevents the server from freezing if any error occurs inside it's loop.

Changes proposed in this pull request:
- Move the try/except block to contain all code in the server loop

@brandogw  please test, I played around with it for a while and it seemed to resolve the issue you found.