### PR TITLE
Putting commandbroadcast back

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -58,6 +58,7 @@ async def on_command(sid, data):
     if immediate:
         clear_broadcast(param)
         command_queue.insert(0, {'param': param, 'value': value, 'type': IMMEDIATE})
+    await sio.emit('commandbroadcast', data, namespace = '/dpu-evolver')
 
 @sio.on('getconfig', namespace = '/dpu-evolver')
 async def on_getlastcommands(sid, data):


### PR DESCRIPTION
# What? Why?
Puts back the `commandbroadcast` for the GUI to receive acknowledgement of commands
Changes proposed in this pull request:
- Put the emit back in the `on_command` function
