### PR TITLE
Adding UTC timestamp to data broadcast

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -363,6 +363,7 @@ async def broadcast(commands_in_queue):
     broadcast_data['config'] = evolver_conf['experimental_params']
     if not commands_in_queue:
         print('Broadcasting data', flush = True)
-        print(broadcast_data)
         broadcast_data['ip'] = evolver_conf['evolver_ip']
+        broadcast_data['timestamp'] = time.time()
+        print(broadcast_data, flush = True)
         await sio.emit('broadcast', broadcast_data, namespace='/dpu-evolver')


### PR DESCRIPTION
Signed-off-by: Zachary Heins <zackheins@gmail.com>

# What? Why?
Having a timestamp on the broadcast would be generally useful for debugging. We are noticing very quick successive broadcasts in the electron app and dpu - this would guide our debugging efforts and could have potential future uses.
Changes proposed in this pull request:
- Adding UTC timestamp to data broadcast

# Checks
- [x] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
