### PR TITLE
Adding a delay for long serial messages

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -286,6 +286,7 @@ def serial_communication(param, value, comm_type):
     serial_output = param + ','.join(output) + ',' + evolver_conf['serial_end_outgoing']
     print(serial_output)
     serial_connection.write(bytes(serial_output, 'UTF-8'))
+    time.sleep(.05)
 
     # Read and process the response
     response = serial_connection.readline().decode('UTF-8', errors='ignore')


### PR DESCRIPTION
# What? Why?
Long serial messages can collide with subsequent messages. Noticed during chemostat pump commands.

Changes proposed in this pull request:
- Add a delay after the first serial message is sent out to give time for message to be sent, received, and the response to be written out.

# Checks
- [x] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

