### PR TITLE
Report serial comm failures back via socket

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -244,6 +244,7 @@ def run_commands():
                 data[command['param']] = returned_data
         except (TypeError, ValueError, serial.serialutil.SerialException, EvolverSerialError) as e:
             print_exc(file = sys.stdout)
+            await sio.emit('serialexception', command, namespace = '/dpu-evolver')
     return data
 
 def serial_communication(param, value, comm_type):


### PR DESCRIPTION
# What? Why?
Alert server clients that an exception/failure occurred during serial communications with micro controllers. Allows clients to repeat a command if it didn't work.

Changes proposed in this pull request:
- On exceptions during `serial_communication` function, report back on event name `serialexception` with the failed command as the payload.