### PR TITLE
Command added to queue use directly passed value instead of file lookup

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -63,7 +63,7 @@ async def on_command(sid, data):
 
     if immediate:
         clear_broadcast(param)
-        command_queue.insert(0, {'param': param, 'value': evolver_conf['experimental_params'][param]['value'], 'type': IMMEDIATE})
+        command_queue.insert(0, {'param': param, 'value': value, 'type': IMMEDIATE})
     await sio.emit('commandbroadcast', data, namespace = '/dpu-evolver')
 
 @sio.on('getconfig', namespace = '/dpu-evolver')


### PR DESCRIPTION
# What? Why?
Fixes #56 . Commands added to the queue have their values directly passed in as opposed to being looked up in the conf.
Changes proposed in this pull request:
- Directly pass value for commands to the queue.