### PR TITLE
Added missing async in from of run_commands

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -233,7 +233,7 @@ def clear_broadcast(param=None):
             command_queue.pop(i)
             break
 
-def run_commands():
+async def run_commands():
     global command_queue, serial_connection
     data = {}
     while len(command_queue) > 0:


### PR DESCRIPTION
# What? Why?

The await function in `run_commands` requires they async keyword in front of the function definition.

Changes proposed in this pull request:
Added await keyword.
