### PR TITLE
Updating LED power to 4095

### DIFF
--- a/evolver/conf.yml
+++ b/evolver/conf.yml
@@ -15,7 +15,7 @@ experimental_params:
     recurring: true
     fields_expected_outgoing: 17
     fields_expected_incoming: 17
-    value: ['2500','2500','2500','2500','2500','2500','2500','2500','2500','2500','2500','2500','2500','2500','2500','2500']
+    value: ['4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095']
   temp:
     recurring: true
     fields_expected_outgoing: 17


### PR DESCRIPTION
Updating the power levels in the configuration for the most current eVOLVER design (high resistor value, OD 90 degree).

`2060` should beused for the OD 135 degree, 51M ohm resistor pack. 