### PR TITLE
Increasing serial delays

### DIFF
--- a/evolver/conf.yml
+++ b/evolver/conf.yml
@@ -56,7 +56,8 @@ serial_end_outgoing: "_!"
 serial_end_incoming: end
 serial_port: '/dev/ttyAMA0'
 serial_baudrate: 9600
-serial_timeout: 0.3
+serial_timeout: 1
+serial_delay: .1
 
 recurring_command_char: r
 immediate_command_char: i

--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -276,7 +276,7 @@ def serial_communication(param, value, comm_type):
     serial_output = param + ','.join(output) + ',' + evolver_conf['serial_end_outgoing']
     print(serial_output)
     serial_connection.write(bytes(serial_output, 'UTF-8'))
-    time.sleep(.05)
+    time.sleep(evolver_conf['serial_delay'])
 
     # Read and process the response
     response = serial_connection.readline().decode('UTF-8', errors='ignore')
@@ -306,7 +306,7 @@ def serial_communication(param, value, comm_type):
     serial_connection.write(bytes(serial_output, 'UTF-8'))
 
     # This is necessary to allow the ack to be fully written out to samd21 and for them to fully read
-    time.sleep(.05)
+    time.sleep(evolver_conf['serial_delay'])
 
     if returned_data[0] == evolver_conf['data_response_char']:
         returned_data = returned_data[1:]


### PR DESCRIPTION
# What? Why?
Addresses #63 

If serial commands were too long, they would not have enough time to transmit with the timing setup. Incresing both the serial timeout and the time to wait between subsequent serial commands to minimize the chance of this happening.

Changes proposed in this pull request:
- Increase serial delays
- Make the sleep timing a variable in the conf file.
