### PR TITLE
added pre/post commands and ODLED

### DIFF
--- a/evolver/conf.yml
+++ b/evolver/conf.yml
@@ -1,65 +1,76 @@
----
-# eVOLVER experimental parameter configurations
-experimental_params:
-  od_90:
-    recurring: true
-    fields_expected_outgoing: 2
-    fields_expected_incoming: 17
-    value: '1000'
-  od_135:
-    recurring: true
-    fields_expected_outgoing: 2
-    fields_expected_incoming: 17
-    value: '1000'
-  od_led:
-    recurring: true
-    fields_expected_outgoing: 17
-    fields_expected_incoming: 17
-    value: ['4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095']
-  temp:
-    recurring: true
-    fields_expected_outgoing: 17
-    fields_expected_incoming: 17
-    value: ['4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095']
-  stir:
-    recurring: true
-    fields_expected_outgoing: 17
-    fields_expected_incoming: 17
-    value: ['8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8']
-  pump:
-    recurring: false
-    fields_expected_outgoing: 49
-    fields_expected_incoming: 49
-    value: null
-  lxml:
-    recurring: false
-    fields_expected_outgoing: 17
-    fields_expected_incoming: 17
-    value: ['4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095']
-
-# eVOLVER server parameter configurations
-broadcast_timing: 20
-num_sleeves: 16
-port: 8081
-
-# RPi file locations and names
-device: evolver-config.json
+acknowledge_char: a
+broadcast_timing: 90
 calibration: calibration.json
 calibrations_directory: calibrations
-fitted_data_directory: fittedCal
-raw_data_directory: rawCal
-od_calibration_directory: od
-temp_calibration_directory: temp
-
-# Serial communication
-serial_end_outgoing: "_!"
-serial_end_incoming: end
-serial_port: '/dev/ttyAMA0'
-serial_baudrate: 9600
-serial_timeout: 0.3
-
-recurring_command_char: r
-immediate_command_char: i
-echo_response_char: e
 data_response_char: b
-acknowledge_char: a
+device: evolver-config.json
+echo_response_char: e
+evolver_ip: 192.168.1.9
+experimental_params:
+  lux: 
+    fields_expected_incoming: 33
+    fields_expected_outgoing: 2
+    recurring: true
+    value: '4'
+  lxml:
+    fields_expected_incoming: 17
+    fields_expected_outgoing: 17
+    recurring: false
+    value: ['4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095',
+      '4095', '4095', '4095', '4095', '4095', '4095', '4095']
+  od_led:
+    fields_expected_incoming: 17
+    fields_expected_outgoing: 17
+    recurring: false
+    value: ['0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+      '0', '0']
+  od_90:
+    fields_expected_incoming: 17
+    fields_expected_outgoing: 2
+    pre:
+    - {param: od_led, value: values}
+    - {param: wait, value: 15}
+    post:
+    - {param: od_led, value: ['0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+      '0', '0']}
+    - {param: wait, value: 15}
+    recurring: true
+    value: '1000'
+  pres:
+    fields_expected_incoming: 9
+    fields_expected_outgoing: 9
+    recurring: true
+    value: ['0', '0', '0', '0', '0', '0', '0', '0']
+  pump:
+    fields_expected_incoming: 49
+    fields_expected_outgoing: 49
+    recurring: false
+    value: ['0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+      '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+      '0', '0']
+  stir:
+    fields_expected_incoming: 17
+    fields_expected_outgoing: 17
+    recurring: true
+    value: ['10', '10', '10', '10', '10', '10', '10', '10', '10', '10', '10', '10',
+      '10', '10', '10', '10']
+  temp:
+    fields_expected_incoming: 17
+    fields_expected_outgoing: 17
+    recurring: true
+    value: ['1602', '1605', '1605', '1612', '1594', '1611', '1593', '1592', '1595',
+      '1598', '1742', '1587', '1594', '1612', '1591', '1603']
+fitted_data_directory: fittedCal
+immediate_command_char: i
+num_sleeves: 16
+od_calibration_directory: od
+port: 8081
+raw_data_directory: rawCal
+recurring_command_char: r
+serial_baudrate: 9600
+serial_end_incoming: end
+serial_end_outgoing: _!
+serial_port: /dev/ttyAMA0
+serial_timeout: 0.5
+temp_calibration_directory: temp

--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -239,6 +239,9 @@ async def run_commands():
     while len(command_queue) > 0:
         command = command_queue.pop(0)
         try:
+            if command['param']=='wait':
+                time.sleep(command['value'])
+                continue
             returned_data = serial_communication(command['param'], command['value'], command['type'])
             if returned_data is not None:
                 data[command['param']] = returned_data
@@ -276,7 +279,7 @@ def serial_communication(param, value, comm_type):
     serial_output = param + ','.join(output) + ',' + evolver_conf['serial_end_outgoing']
     print(serial_output)
     serial_connection.write(bytes(serial_output, 'UTF-8'))
-    time.sleep(.05)
+    time.sleep(.5)
 
     # Read and process the response
     response = serial_connection.readline().decode('UTF-8', errors='ignore')
@@ -306,7 +309,7 @@ def serial_communication(param, value, comm_type):
     serial_connection.write(bytes(serial_output, 'UTF-8'))
 
     # This is necessary to allow the ack to be fully written out to samd21 and for them to fully read
-    time.sleep(.05)
+    time.sleep(.5)
 
     if returned_data[0] == evolver_conf['data_response_char']:
         returned_data = returned_data[1:]
@@ -332,14 +335,39 @@ def get_num_commands():
     global command_queue
     return len(command_queue)
 
+def process_commands(commands_in_queue,parameters):
+    """
+        Add all recommands and pre/post commands to the command queue
+    """
+    for param, config in parameters.items():
+        if config['recurring']:
+            if "pre" in config: # run this command prior to the main command
+                sub_command(config['pre'],parameters)
+
+            # Main command
+            command_queue.append({'param': param, 'value': config['value'], 'type':RECURRING})
+
+            if "post" in config: # run this command after the main command
+                sub_command(config['post'],parameters)
+
+def sub_command(command_list,parameters):
+    """
+        Run a seperate list of commands called for by the main parameter command
+    """
+    for command in command_list:
+        parameter = command['param']
+        value = command['value']
+        if value == 'values':
+            value = parameters[parameter]['value']
+        command_queue.append({'param': parameter, 'value': value, 'type':IMMEDIATE})
+
 async def broadcast(commands_in_queue):
     global command_queue
     broadcast_data = {}
     clear_broadcast()
     if not commands_in_queue:
-        for param, config in evolver_conf['experimental_params'].items():
-            if config['recurring']:
-                command_queue.append({'param': param, 'value': config['value'], 'type':RECURRING})
+        process_commands(commands_in_queue,evolver_conf['experimental_params'])
+
     # Always run commands so that IMMEDIATE requests occur. RECURRING requests only happen if no commands in queue
     broadcast_data['data'] = await run_commands()
     broadcast_data['config'] = evolver_conf['experimental_params']


### PR DESCRIPTION
# What? Why?
Added support for commands run before/after a given command's execution. For example, this is useful for turning off additional LEDs before taking an OD reading, so that measured OD is unaffected.

Changes proposed in this pull request:
- conf.yml contains an example where the OD LED is turned off until it is time for a reading, at which point it is turned on
- evolver_server.py reads and executes "pre" (before main command) commands and "post" (after main) commands. Special "wait" commands are attached to pre and post commands, which pause the server until the number of seconds have elapsed.

# Checks
- [ ] Updated the documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
No