### PR TITLE
Added pre and post commands in conf, with support in server

### DIFF
--- a/evolver/alternate_conf_files/odled_normally_off/conf.yml
+++ b/evolver/alternate_conf_files/odled_normally_off/conf.yml
@@ -1,0 +1,73 @@
+---
+# eVOLVER experimental parameter configurations
+experimental_params:
+  od_90:
+    recurring: true
+    fields_expected_outgoing: 2
+    fields_expected_incoming: 17
+    value: '1000'
+    pre:
+    - param: 'od_led'
+      value: 'values'
+    - param: 'wait'
+      value: 15
+    post:
+    - param: 'od_led'
+      value: ['0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0']
+  od_135:
+    recurring: true
+    fields_expected_outgoing: 2
+    fields_expected_incoming: 17
+    value: '1000'
+  od_led:
+    recurring: true
+    fields_expected_outgoing: 17
+    fields_expected_incoming: 17
+    value: ['4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095']
+  temp:
+    recurring: true
+    fields_expected_outgoing: 17
+    fields_expected_incoming: 17
+    value: ['4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095', '4095']
+  stir:
+    recurring: true
+    fields_expected_outgoing: 17
+    fields_expected_incoming: 17
+    value: ['8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8', '8']
+  pump:
+    recurring: false
+    fields_expected_outgoing: 49
+    fields_expected_incoming: 49
+    value: null
+  lxml:
+    recurring: false
+    fields_expected_outgoing: 17
+    fields_expected_incoming: 17
+    value: ['4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095','4095']
+
+# eVOLVER server parameter configurations
+broadcast_timing: 60
+num_sleeves: 16
+port: 8081
+
+# RPi file locations and names
+device: evolver-config.json
+calibration: calibration.json
+calibrations_directory: calibrations
+fitted_data_directory: fittedCal
+raw_data_directory: rawCal
+od_calibration_directory: od
+temp_calibration_directory: temp
+
+# Serial communication
+serial_end_outgoing: "_!"
+serial_end_incoming: end
+serial_port: '/dev/ttyAMA0'
+serial_baudrate: 9600
+serial_timeout: 0.3
+
+recurring_command_char: r
+immediate_command_char: i
+echo_response_char: e
+data_response_char: b
+acknowledge_char: a

--- a/evolver/alternate_conf_files/readme.md
+++ b/evolver/alternate_conf_files/readme.md
@@ -1,0 +1,37 @@
+Server Configuration Files (conf.yml)
+===
+
+## Summary
+
+Configuration files (conf.yml) contain the parameters for the server to run.
+
+More complex conf.yml files including 'pre' and 'post' commands are complicated to repeatedly alter, so storing them allows easy switching to files for different purposes.
+
+## Definitions
+subcommand = a command added to the command queue when another command is run
+
+An example subcommand:
+```
+- param: 'od_led'
+  value: ['0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0']
+```
+
+'pre' or 'post' command = a list of subcommands to be added to the command queue before or after the main parameter command
+
+'values' = a keyword referencing the current value of a parameter in the conf file (for example, the subcommand) 
+```
+- param: 'temp'
+  value: 'values'
+```
+
+'wait' = a special type of subcommand that makes the server pause for that many seconds (for example so that a command can execute)
+```
+- param: 'wait'
+  value: 15
+```
+
+
+## Examples of potential alternate conf files
+Calibration conf - broadcast_timing parameter should be low to speed up calibration
+
+Experiment conf - the OD LED might need to be normally off unless OD is read to prevent the light affecting sensors


### PR DESCRIPTION
# What? Why?
Added support for commands run before/after a given command's execution. For example, this is useful for turning off additional LEDs before taking an OD reading, so that measured OD is unaffected.

# Changes proposed in this pull request:
- evolver_server.py reads and executes "pre" (before main command) commands and "post" (after main) commands. 
- Made alternative conf file folder, where conf files for different purposes can be added
- Added an example where the OD LED is turned off until it is time for a reading, at which point it is turned on
- Special "wait" commands are attached to pre and post commands, which pause the server until the number of seconds have elapsed.
- An explanation of conf files and pre / post commands has been added

# Checks
- [x] Updated the documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
