### PR TITLE
Indexing fix for single commands

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -262,7 +262,7 @@ def serial_communication(param, value, comm_type):
        output = output + list(map(str,value))
        for i,command_value in enumerate(output):
             if command_value == 'NaN':
-                output[i] = evolver_conf['experimental_params'][param]['value'][i]
+                output[i] = evolver_conf['experimental_params'][param]['value'][i-1]
 
     else:
         output.append(value)


### PR DESCRIPTION
# What? Why?
When sending a command over the GUI to a single selected vial, the server would hang up. This was caused by an index exception that doesn't get logged that killed the child process.
Changes proposed in this pull request:
- Fix indexing into the conf for NaN values in serial_communications function.