### PR TITLE
Fix async call in run_commands

### DIFF
--- a/evolver/evolver_server.py
+++ b/evolver/evolver_server.py
@@ -244,7 +244,6 @@ def run_commands():
                 data[command['param']] = returned_data
         except (TypeError, ValueError, serial.serialutil.SerialException, EvolverSerialError) as e:
             print_exc(file = sys.stdout)
-            await sio.emit('serialexception', command, namespace = '/dpu-evolver')
     return data
 
 def serial_communication(param, value, comm_type):


### PR DESCRIPTION
# What? Why?
Removing async call in the run_commands function. This causes problems as the calling function is not async.
